### PR TITLE
fixed prj-liftbased example

### DIFF
--- a/samples/prj-liftbased/pom.xml
+++ b/samples/prj-liftbased/pom.xml
@@ -12,7 +12,7 @@
   <name>toto01 Project</name>
   <inceptionYear>2010</inceptionYear>
   <properties>
-    <scala.version>2.8.0.RC6</scala.version>
+    <scala.version>2.8.0</scala.version>
     <!-- Common plugin settings -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>${project.build.sourceEncoding}</project.reporting.outputEncoding>

--- a/samples/prj-liftbased/src/main/webapp/templates-hidden/default.html
+++ b/samples/prj-liftbased/src/main/webapp/templates-hidden/default.html
@@ -1,0 +1,10 @@
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <title>Lift Example</title>
+  </head>
+  <body>
+    <lift:bind name="content" />
+    <lift:Menu.builder />
+    <lift:msgs/>
+  </body>
+</html>


### PR DESCRIPTION
Hello,

I tried the Lift based example and had a few issues. These are the fixes for them.

fixed prj-liftbased example
- changed scala.version in pom.xml to 2.8.0
- added default.html in templates-hidden folder (previously omitted)
- fixed issue with pages not displaying properly in FF and Chrome, previously displayed as XML file because of "application/xhtml+xml" content-type and malformed html

Thank you,
Taylor Leese
