### PR TITLE
update to 0.13 m2e at git.eclipse.org

### DIFF
--- a/.project
+++ b/.project
@@ -6,12 +6,12 @@
 	</projects>
 	<buildSpec>
 		<buildCommand>
-			<name>org.maven.ide.eclipse.maven2Builder</name>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
 			<arguments>
 			</arguments>
 		</buildCommand>
 	</buildSpec>
 	<natures>
-		<nature>org.maven.ide.eclipse.maven2Nature</nature>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 	</natures>
 </projectDescription>

--- a/org.maven.ide.eclipse.scala/.project
+++ b/org.maven.ide.eclipse.scala/.project
@@ -20,8 +20,14 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>

--- a/org.maven.ide.eclipse.scala/META-INF/MANIFEST.MF
+++ b/org.maven.ide.eclipse.scala/META-INF/MANIFEST.MF
@@ -8,9 +8,9 @@ Require-Bundle:
  org.eclipse.jdt.core,
  org.eclipse.core.runtime,
  org.eclipse.core.resources,
- org.maven.ide.eclipse,
- org.maven.ide.eclipse.maven_embedder,
- org.maven.ide.eclipse.jdt,
+ org.eclipse.m2e.core,
+ org.eclipse.m2e.maven.runtime,
+ org.eclipse.m2e.jdt,
  org.eclipse.jdt.launching
 Bundle-Vendor: Sonatype, Inc.
 Export-Package: org.maven.ide.eclipse.scala

--- a/org.maven.ide.eclipse.scala/build.properties
+++ b/org.maven.ide.eclipse.scala/build.properties
@@ -2,4 +2,5 @@ source.. = src/
 output.. = target/classes
 bin.includes = META-INF/,\
                .,\
-               plugin.xml
+               plugin.xml,\
+               lifecycle-mapping-metadata.xml

--- a/org.maven.ide.eclipse.scala/lifecycle-mapping-metadata.xml
+++ b/org.maven.ide.eclipse.scala/lifecycle-mapping-metadata.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lifecycleMappingMetadata>
+
+  <pluginExecutions>
+    <!--  scala maven plugins -->
+    <pluginExecution>
+      <pluginExecutionFilter>
+        <groupId>org.scala-tools</groupId>
+        <artifactId>maven-scala-plugin</artifactId>
+        <goals>
+          <goal>compile</goal>
+          <goal>testCompile</goal>
+        </goals>
+        <versionRange>[2.0,)</versionRange> <!-- mkleint: not entirely sure if there is a limit, so shot for a wide range -->
+      </pluginExecutionFilter>
+      <action>
+          <configurator>
+            <id>org.maven.ide.eclipse.scala</id>
+          </configurator>
+      </action>
+    </pluginExecution>
+  </pluginExecutions>
+</lifecycleMappingMetadata>

--- a/org.maven.ide.eclipse.scala/plugin.xml
+++ b/org.maven.ide.eclipse.scala/plugin.xml
@@ -11,6 +11,11 @@
             >
       </configurator>
    </extension>
+   <!-- marker extension point, mappings read from ./lifecycle-mapping-metadata.xml file -->
+   <extension
+         point="org.eclipse.m2e.core.lifecycleMappingMetadataSource">
+   </extension>   
+   
    <extension point="org.eclipse.m2e.core.archetypeCatalogs">
       <remote description="Scala-tools.org/releases Catalog" url="http://nexus.scala-tools.org/content/repositories/releases/"/>
       <remote description="Scala-tools.org/snapshots Catalog" url="http://nexus.scala-tools.org/content/repositories/snapshots/"/>

--- a/org.maven.ide.eclipse.scala/plugin.xml
+++ b/org.maven.ide.eclipse.scala/plugin.xml
@@ -2,7 +2,7 @@
 <?eclipse version="3.2"?>
 <plugin>
    <extension
-         point="org.maven.ide.eclipse.projectConfigurators">
+         point="org.eclipse.m2e.core.projectConfigurators">
          <!-- priority="98" generic="false" -->
       <configurator
             class="org.maven.ide.eclipse.scala.ScalaProjectConfigurator"
@@ -11,7 +11,7 @@
             >
       </configurator>
    </extension>
-   <extension point="org.maven.ide.eclipse.archetypeCatalogs">
+   <extension point="org.eclipse.m2e.core.archetypeCatalogs">
       <remote description="Scala-tools.org/releases Catalog" url="http://nexus.scala-tools.org/content/repositories/releases/"/>
       <remote description="Scala-tools.org/snapshots Catalog" url="http://nexus.scala-tools.org/content/repositories/snapshots/"/>
    </extension>

--- a/org.maven.ide.eclipse.scala/src/org/maven/ide/eclipse/scala/ScalaProjectConfigurator.java
+++ b/org.maven.ide.eclipse.scala/src/org/maven/ide/eclipse/scala/ScalaProjectConfigurator.java
@@ -22,12 +22,12 @@ import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.launching.JavaRuntime;
-import org.maven.ide.eclipse.jdt.IClasspathDescriptor;
-import org.maven.ide.eclipse.jdt.IClasspathEntryDescriptor;
-import org.maven.ide.eclipse.jdt.IJavaProjectConfigurator;
-import org.maven.ide.eclipse.project.IMavenProjectFacade;
-import org.maven.ide.eclipse.project.configurator.AbstractProjectConfigurator;
-import org.maven.ide.eclipse.project.configurator.ProjectConfigurationRequest;
+import org.eclipse.m2e.jdt.IClasspathDescriptor;
+import org.eclipse.m2e.jdt.IClasspathEntryDescriptor;
+import org.eclipse.m2e.jdt.IJavaProjectConfigurator;
+import org.eclipse.m2e.core.project.IMavenProjectFacade;
+import org.eclipse.m2e.core.project.configurator.AbstractProjectConfigurator;
+import org.eclipse.m2e.core.project.configurator.ProjectConfigurationRequest;
 
 //TODO check the jre/java version compliance (>= 1.5)
 //TODO check JDT Weaving is enabled (if not enabled, icon of scala file is [J] same as java (and property of  the file display "Type :... Java Source File" )

--- a/org.maven.ide.eclipse.scala_feature/.project
+++ b/org.maven.ide.eclipse.scala_feature/.project
@@ -16,14 +16,14 @@
 			</arguments>
 		</buildCommand>
 		<buildCommand>
-			<name>org.maven.ide.eclipse.maven2Builder</name>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
 			<arguments>
 			</arguments>
 		</buildCommand>
 	</buildSpec>
 	<natures>
 		<nature>org.eclipse.jdt.core.javanature</nature>
-		<nature>org.maven.ide.eclipse.maven2Nature</nature>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
 </projectDescription>

--- a/org.maven.ide.eclipse.scala_site/.project
+++ b/org.maven.ide.eclipse.scala_site/.project
@@ -16,14 +16,14 @@
 			</arguments>
 		</buildCommand>
 		<buildCommand>
-			<name>org.maven.ide.eclipse.maven2Builder</name>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
 			<arguments>
 			</arguments>
 		</buildCommand>
 	</buildSpec>
 	<natures>
 		<nature>org.eclipse.jdt.core.javanature</nature>
-		<nature>org.maven.ide.eclipse.maven2Nature</nature>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.pde.UpdateSiteNature</nature>
 	</natures>
 </projectDescription>

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <repository>
       <id>m2eclipse</id>
       <layout>p2</layout>
-      <url>http://m2eclipse.sonatype.org/sites/m2e/</url>
+      <url>https://repository.sonatype.org/content/sites/forge-sites/m2e/0.13.0/N/0.13.0.201101251704/</url>
     </repository>
     <repository>
       <id>scala-ide</id>


### PR DESCRIPTION
Hello,

I've updated the sources to use the (repackaged) m2e from eclipse.org. Apart from that I've also added the lifecycle mapping definition for the scala compile goals and bound them to the scala configurator. Since 0.13 projects containing unknown plugin executions are marked with errors.
When applying, it would be great to create an entry in the m2e catalog with the updated code binaries, so that people can flawlessly work with projects containing scala and easily find the scala/maven integration bridging when needed. See https://docs.sonatype.com/display/M2E/M2E+Catalog for process how to include plugins to the catalog.

It would be great if the m2e-scala bridge would define dependencies on the scala _and_ m2e support plugins, so that when people install the m2e-scala bridge, they get the full fledged scala support as well. it's not currently the case.

Best Regards

Milos Kleint
