### PR TITLE
issue #8 : Add basic WTP support

### DIFF
--- a/org.maven.ide.eclipse.scala/META-INF/MANIFEST.MF
+++ b/org.maven.ide.eclipse.scala/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Maven Integration for Scala IDE
 Bundle-SymbolicName: org.maven.ide.eclipse.scala;singleton:=true
-Bundle-Version: 0.4.1
+Bundle-Version: 0.4.2.qualifier
 Bundle-RequiredExecutionEnvironment: J2SE-1.5
 Require-Bundle: 
  org.eclipse.jdt.core,

--- a/org.maven.ide.eclipse.scala/pom.xml
+++ b/org.maven.ide.eclipse.scala/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.maven.ide.eclipse.scala</groupId>
     <artifactId>m2eclipse-scala</artifactId>
-    <version>0.4.1</version>
+    <version>0.4.2-SNAPSHOT</version>
   </parent>
   <artifactId>org.maven.ide.eclipse.scala</artifactId>
   <packaging>eclipse-plugin</packaging>

--- a/org.maven.ide.eclipse.scala_feature/feature.xml
+++ b/org.maven.ide.eclipse.scala_feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.maven.ide.eclipse.scala_feature"
       label="Maven Integration for Scala IDE"
-      version="0.4.1"
+      version="0.4.2.qualifier"
       provider-name="Sonatype, Inc.">
 
    <description url="github.com/sonatype/m2eclipse-scala/">

--- a/org.maven.ide.eclipse.scala_feature/pom.xml
+++ b/org.maven.ide.eclipse.scala_feature/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.maven.ide.eclipse.scala</groupId>
     <artifactId>m2eclipse-scala</artifactId>
-    <version>0.4.1</version>
+    <version>0.4.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.maven.ide.eclipse.scala_feature</artifactId>

--- a/org.maven.ide.eclipse.scala_site/pom.xml
+++ b/org.maven.ide.eclipse.scala_site/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.maven.ide.eclipse.scala</groupId>
     <artifactId>m2eclipse-scala</artifactId>
-    <version>0.4.1</version>
+    <version>0.4.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>    
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,11 +4,11 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.maven.ide.eclipse.scala</groupId>
   <artifactId>m2eclipse-scala</artifactId>
-  <version>0.4.1</version>
+  <version>0.4.2-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <properties>
-    <tycho.version>0.14.1</tycho.version>
+    <tycho.version>0.15.0</tycho.version>
     <encoding>UTF-8</encoding>
   </properties>
 


### PR DESCRIPTION
Adds the same deployable attribute to the Scala classpath container as the one added to the Maven container by m2e-wtp. If m2e-wtp or WTP is not installed, this will be ignored.

This could still be improved by setting deployment attribute on a more fine grained level, i.e. on each classpath entry from the scala lib.

PR also updates the tycho version and m2e-scala version used to build.
