### PR TITLE
Eclipse job compliance

### DIFF
--- a/org.maven.ide.eclipse.scala/src/org/maven/ide/eclipse/scala/ScalaProjectConfigurator.java
+++ b/org.maven.ide.eclipse.scala/src/org/maven/ide/eclipse/scala/ScalaProjectConfigurator.java
@@ -206,11 +206,18 @@ public class ScalaProjectConfigurator extends AbstractJavaProjectConfigurator {
         try {
           IClasspathEntry[] classpathEntries = javaProject.getRawClasspath();
 
-          List<IClasspathEntry> entries = new ArrayList<IClasspathEntry>(classpathEntries.length);
-          Collections.addAll(entries, classpathEntries);
+          Boolean sorted = true;
+          for (int i = 0; i < classpathEntries.length - 1; i++) {
+            if (comparator.compare(classpathEntries[i], classpathEntries[i+1]) > 0){sorted = false; break;}
+          }
 
-          Collections.sort(entries, comparator);
-          javaProject.setRawClasspath(entries.toArray(new IClasspathEntry[entries.size()]), monitor);
+          if(!sorted) {
+            List<IClasspathEntry> entries = new ArrayList<IClasspathEntry>(classpathEntries.length);
+            Collections.addAll(entries, classpathEntries);
+
+            Collections.sort(entries, comparator);
+            javaProject.setRawClasspath(entries.toArray(new IClasspathEntry[entries.size()]), monitor);
+          }
           return Status.OK_STATUS;
         } catch(JavaModelException e) {
           return Status.CANCEL_STATUS;

--- a/org.maven.ide.eclipse.scala/src/org/maven/ide/eclipse/scala/ScalaProjectConfigurator.java
+++ b/org.maven.ide.eclipse.scala/src/org/maven/ide/eclipse/scala/ScalaProjectConfigurator.java
@@ -276,6 +276,7 @@ public class ScalaProjectConfigurator extends AbstractJavaProjectConfigurator {
   throws JavaModelException, CoreException {
     if (javaProject == null) return;
     ClasspathContainerInitializer scalaInitializer = JavaCore.getClasspathContainerInitializer(SCALA_CONTAINER_PATH);
+    if (scalaInitializer == null) return;
     IPath scalaContainerPath = Path.fromPortableString(SCALA_CONTAINER_PATH);
     Boolean updateAble = scalaInitializer.canUpdateClasspathContainer(scalaContainerPath, javaProject);
     final IClasspathContainer scalaLibrary = JavaCore.getClasspathContainer(scalaContainerPath, javaProject);


### PR DESCRIPTION
Several steps with the intent of mitigating #30.
- make classpath modifications in Eclipse Jobs
- only change the classpath to a sorted one if it's not sorted already.
- linting
